### PR TITLE
fix firefox

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -81,7 +81,11 @@ html, body {
   left: 0;
 
   svg {
-    display: none;
+    position: fixed;
+    top:0;
+    left:0;
+    width: 0;
+    height: 0;
   }
 
 


### PR DESCRIPTION
in firefox, svg with display none doesn't work.
This update sets the svg to be displayed, with 0 dimension.

It now works in firefox and Chrome

fix https://github.com/baunov/gradients-bg/issues/1
